### PR TITLE
Check Activity state before displaying Dialogs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/caffeine/build.gradle
+++ b/caffeine/build.gradle
@@ -7,7 +7,7 @@ version '1.0-SNAPSHOT'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "23.0.3"
+    buildToolsVersion = "24.0.3"
 
     buildTypes {
         debug {

--- a/caffeine/src/main/java/com/percolate/caffeine/DialogUtils.java
+++ b/caffeine/src/main/java/com/percolate/caffeine/DialogUtils.java
@@ -31,11 +31,13 @@ public class DialogUtils {
         final SpannableString s = new SpannableString(message); //Make links clickable
         Linkify.addLinks(s, Linkify.ALL);
 
-        Builder builder = new AlertDialog.Builder(context);
+        final Builder builder = new AlertDialog.Builder(context);
         builder.setMessage(s);
         builder.setPositiveButton(android.R.string.ok, closeDialogListener());
         AlertDialog dialog = builder.create();
-        dialog.show();
+        if(!context.isFinishing()) {
+            dialog.show();
+        }
 
         ((TextView) dialog.findViewById(android.R.id.message)).setMovementMethod(LinkMovementMethod.getInstance()); //Make links clickable
 

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "23.0.3"
+    buildToolsVersion = "24.0.3"
 
     defaultConfig {
         applicationId "com.percolate.caffeine.testapp"


### PR DESCRIPTION
This PR adds a `Activity#isFinishing())` check before showing Dialogs.  This is added to avoid potential `"android.os.BinderProxy... is not valid; is your activity running?"` errors from occurring.